### PR TITLE
Fix: Redirect trailing slash

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -41,7 +41,7 @@ class RouteServiceProvider extends ServiceProvider
         $this->mapWebRoutes();
 
         Route::middleware(function ($request, \Closure $next) {
-            if ($request->getPathInfo()  !== '/' && ends_with($request->getPathInfo(), '/')) {
+            if ($request->getPathInfo() !== '/' && ends_with($request->getPathInfo(), '/')) {
                 return redirect(rtrim($request->getPathInfo(), '/'), 301);
             }
 

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -40,7 +40,15 @@ class RouteServiceProvider extends ServiceProvider
 
         $this->mapWebRoutes();
 
-        Mozhi::routes();
+        Route::middleware(function ($request, \Closure $next) {
+            if ($request->getPathInfo()  !== '/' && ends_with($request->getPathInfo(), '/')) {
+                return redirect(rtrim($request->getPathInfo(), '/'), 301);
+            }
+
+            return $next($request);
+        })->group(function () {
+            Mozhi::routes();
+        });
     }
 
     /**

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -10,8 +10,8 @@ AddHandler php71-cgi .php
     RewriteCond %{HTTPS} off
     RewriteRule (.*) https://%{HTTP_HOST}/$1 [R=301,L]
 
-    RewriteCond %{HTTP_HOST} ^www\.rathes\.de [NC]
-    RewriteRule ^(.*)$ http://rathes.de/$1 [L,R=301]
+    RewriteCond %{HTTP_HOST} ^www\.rathes\.me [NC]
+    RewriteRule ^(.*)$ http://rathes.me/$1 [L,R=301]
 
     # Redirect Trailing Slashes If Not A Folder...
     RewriteCond %{REQUEST_FILENAME} !-d


### PR DESCRIPTION
Fix that urls with trailing slashes were not redirected to the non-trailing slashes anymore.

This is a temporary fix. Needs further investigations on how this could happen.